### PR TITLE
fix for building workspaces

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -46,7 +46,6 @@ command :build do |c|
     flags << "-configuration #{@configuration}"
 
     ENV['CC'] = nil # Fix for RVM
-    clean_cmd = "xcodebuild #{flags.join(' ')} clean build 1> /dev/null"
     build_cmd = "xcodebuild #{flags.join(' ')} clean build 1> /dev/null"
     abort unless system clean_cmd
     abort unless system build_cmd


### PR DESCRIPTION
Fixed bug with building workspaces, no longer errors about build configurations not being found.

Set the default Build Configuration to Debug (passing a value via -c will override)
