### PR TITLE
Fix for building workspaces

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -98,7 +98,6 @@ command :build do |c|
   end
 
   def determine_configuration!
-    return
     if @xcodebuild_info.build_configurations.length == 1
       @configuration = @xcodebuild_info.build_configurations.first
     else


### PR DESCRIPTION
This fix addresses issues surrounding building a project in a workspace.
1. build.rb does not abort/fail if "Build Configurations" are not found on a workspace project.  "Build Configurations" are not required for workspace builds.
2. build.rb sets the default build configuration to Debug if one is not passed in via the --configuration or -c directives
