### PR TITLE
added double quote fix to xcodebuild settings regex

### DIFF
--- a/lib/shenzhen/xcodebuild.rb
+++ b/lib/shenzhen/xcodebuild.rb
@@ -70,7 +70,7 @@ module Shenzhen::XcodeBuild
       settings, target = {}, nil
       lines.each do |line|
         case line
-        when /Build settings for action build and target (\w+)/
+        when /Build settings for action build and target \"?(\w+)/
           target = $1
           settings[target] = {}
         else


### PR DESCRIPTION
If the Scheme has spaces, a double quote is added to the xcodebuild result string, like:

```
Build settings for action build and target "My Project Scheme"
```

So I just added a optional `"` to the xcodebuild regex to match this case
