### PR TITLE
Removing first line shift of xcodebuild settings output

### DIFF
--- a/lib/shenzhen/xcodebuild.rb
+++ b/lib/shenzhen/xcodebuild.rb
@@ -65,7 +65,6 @@ module Shenzhen::XcodeBuild
       raise NilOutputError unless /\S/ === output
 
       lines = output.split(/\n/)
-      lines.shift
 
       settings, target = {}, nil
       lines.each do |line|


### PR DESCRIPTION
to preserve first target name
