### PR TITLE
Should WRAPPER_NAME replace PRODUCT_NAME during PackageApplication?

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -50,11 +50,12 @@ command :build do |c|
 
     @target, @xcodebuild_settings = Shenzhen::XcodeBuild.settings(*flags).detect{|target, settings| settings['WRAPPER_EXTENSION'] == "app"}
     say_error "App settings could not be found." and abort unless @xcodebuild_settings
-
-    @app_path = File.join(@xcodebuild_settings['BUILT_PRODUCTS_DIR'], @xcodebuild_settings['PRODUCT_NAME']) + ".app"
+    
+    @app_path = File.join(@xcodebuild_settings['BUILT_PRODUCTS_DIR'], @xcodebuild_settings['WRAPPER_NAME'])
     @dsym_path = @app_path + ".dSYM"
-    @dsym_filename = "#{@xcodebuild_settings['PRODUCT_NAME']}.app.dSYM"
-    @ipa_path = File.join(Dir.pwd, @xcodebuild_settings['PRODUCT_NAME']) + ".ipa"
+    @dsym_filename = "#{@xcodebuild_settings['WRAPPER_NAME']}.dSYM"
+    @ipa_name = @xcodebuild_settings['WRAPPER_NAME'].gsub(@xcodebuild_settings['WRAPPER_SUFFIX'], "") + ".ipa"
+    @ipa_path = File.join(Dir.pwd, @ipa_name)
     
     log "xcrun", "PackageApplication"
     abort unless system %{xcrun -sdk iphoneos PackageApplication -v "#{@app_path}" -o "#{@ipa_path}" --embed "#{@dsym_path}" 1> /dev/null}


### PR DESCRIPTION
In [build.rb](https://github.com/mattt/shenzhen/blob/master/lib/shenzhen/commands/build.rb), `PRODUCT_NAME` is being used where I think `WRAPPER_NAME` would be more appropriate. By default, `WRAPPER_NAME` is `PRODUCT_NAME`+`WRAPPER_SUFFIX` (e.g. FooBar.app)

For some of my projects, I override `WRAPPER_NAME` to change the name of the final product file created by Xcode. This is based on [Xcode Build Settings Reference](https://developer.apple.com/library/ios/#documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW105) stating:

> PRODUCT_NAME
> Description: Identifier. Specifies the name of the product the target builds.
> 
> WRAPPER_NAME
> Description: Filename. Specifies the filename (including the appropriate extension) of the product bundle.

This works fine when I build everything through Xcode, but it fails when I attempt to build with shenzhen with the following error:

```
          xcrun  PackageApplication
error: Specified application doesn't exist or isn't a bundle directory : …
```
