### PR TITLE
Added Mandatory Flag

### DIFF
--- a/lib/shenzhen/plugins/hockeyapp.rb
+++ b/lib/shenzhen/plugins/hockeyapp.rb
@@ -54,6 +54,7 @@ command :'distribute:hockeyapp' do |c|
   c.option '--tags TAGS', "Comma separated list of tags which will receive access to the build"
   c.option '--notify', "Notify permitted teammates to install the build"
   c.option '--downloadOff', "Upload but don't allow download of this version just yet"
+  c.option '--mandatory', "Make this update mandatory"
   
   c.action do |args, options|
     determine_file! unless @file = options.file
@@ -76,7 +77,7 @@ command :'distribute:hockeyapp' do |c|
     parameters[:status] = options.downloadOff ? "1" : "2"
     parameters[:tags] = options.tags if options.tags
     parameters[:dsym_filename] = @dsym if @dsym
-
+    parameters[:mandatory] = "1" if options.mandatory
 
     client = Shenzhen::Plugins::HockeyApp::Client.new(@api_token)
     response = client.upload_build(@file, parameters)


### PR DESCRIPTION
I added a --mandatory flag for HockeyApp to fix this issue: https://github.com/mattt/shenzhen/issues/33 (which I created).

One curious note, the mandatory flag doesn't work unless you also supply an app ID. I believe this is a bug in the Hockey API, not Shenzhen.

It might be nice to put a warning in if the user supplies --mandatory but does not submit an app ID. Let me know if you'd like me to do this.

Thanks for all your work!
