### PR TITLE
Scheme name with spaces not being matched

### DIFF
--- a/lib/shenzhen/xcodebuild.rb
+++ b/lib/shenzhen/xcodebuild.rb
@@ -65,7 +65,7 @@ module Shenzhen::XcodeBuild
       raise NilOutputError unless /\S/ === output
 
       lines = output.split(/\n/)
-      lines.shift
+#      lines.shift
 
       settings, target = {}, nil
       lines.each do |line|


### PR DESCRIPTION
Scheme names with embedded spaces are failing to be matched by an incorrect regexp.  Also, it seems that there's a shift on an array that is removing a significant line from the build settings on a project.

See issues:
- #35
- #36
