### PR TITLE
Supporting sending additional flags to xcodebuild from "ipa build" command

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -7,6 +7,7 @@ command :build do |c|
   c.option '-p', '--project PROJECT', 'Project (.xcodeproj) file to use to build app (automatically detected in current directory, overridden by --workspace option, if passed)'
   c.option '-c', '--configuration CONFIGURATION', 'Configuration used to build'
   c.option '-s', '--scheme SCHEME', 'Scheme used to build app'
+  c.option '-f', '--flags FLAGS', 'Additional flags provided to xcodebuild'
   c.option '--[no-]clean', 'Clean project before building'
   c.option '--[no-]archive', 'Archive project after building'
 
@@ -39,6 +40,7 @@ command :build do |c|
     flags << "-project '#{@project}'" if @project
     flags << "-scheme '#{@scheme}'" if @scheme
     flags << "-configuration '#{@configuration}'"
+    flags << options.flags
 
     actions = []
     actions << :clean unless options.clean == false


### PR DESCRIPTION
Flags will be passed to xcodebuild to support options such as setting ONLY_ACTIVE_ARCH=NO or similar when xcodebuild is being called
