### PR TITLE
Fix an issue where S3 --path option wouldn't match plist replacements

### DIFF
--- a/lib/shenzhen/plugins/s3.rb
+++ b/lib/shenzhen/plugins/s3.rb
@@ -36,7 +36,7 @@ module Shenzhen::Plugins
         Dir.mktmpdir do |dir|
           system "unzip -q #{ipa} -d #{dir} 2> /dev/null"
 
-          plist = Dir["#{dir}/**/Info.plist"].last
+          plist = Dir["#{dir}/**/*.app/Info.plist"].last
 
           substitutions.uniq.each do |substitution|
             key = substitution[1...-1]


### PR DESCRIPTION
The issue was because `Dir["#{dir}/**/Info.plist"]` is returning all plists in the project, this will include compiled storyboards and any other file matching Info.plist. Instead, this now explicitly checks for an Info.plist located within *.app.
