### PR TITLE
Add release_type options for hockeyapp.

### DIFF
--- a/lib/shenzhen/plugins/hockeyapp.rb
+++ b/lib/shenzhen/plugins/hockeyapp.rb
@@ -51,7 +51,7 @@ command :'distribute:hockeyapp' do |c|
   c.option '-t', '--token TOKEN', "API Token. Available at https://rink.hockeyapp.net/manage/auth_tokens"
   c.option '-i', '--identifier PUBLIC_IDENTIFIER', "Public identifier of the app you are targeting, if not specified HockeyApp will use the bundle identifier to choose the right"
   c.option '-m', '--notes NOTES', "Release notes for the build (Default: Textile)"
-  c.option '-r', '--release RELEASE', "Release type - Beta = 0, Live = 1, Alpha = 2 (Default: Alpha)"
+  c.option '-r', '--release RELEASE', "Release type: 0 - Beta, 1 - Live, 2 - Alpha (Default: 2)"
   c.option '--markdown', 'Notes are written with Markdown'
   c.option '--tags TAGS', "Comma separated list of tags which will receive access to the build"
   c.option '--notify', "Notify permitted teammates to install the build"


### PR DESCRIPTION
Hockeyapp has a release_type param that I needed access to: http://support.hockeyapp.net/kb/api/api-apps

(please excuse my limited knowledge in ruby) 
