### PR TITLE
Warning user about UTF-8 console encoding

### DIFF
--- a/bin/ipa
+++ b/bin/ipa
@@ -1,5 +1,12 @@
 #!/usr/bin/env ruby
 
+if Encoding.default_external != Encoding::UTF_8
+  puts <<-DOC
+  \e[33m
+  WARNING: Shenzhen requires your terminal to be using UTF-8 encoding.\e[0m\n
+  DOC
+end
+
 require 'dotenv'
 Dotenv.load
 


### PR DESCRIPTION
I was getting this error on Jenkins CI: 

```
+ ipa build --trace
/Library/Ruby/Gems/2.0.0/gems/shenzhen-0.5.3/lib/shenzhen/xcodebuild.rb:64:in `===': invalid byte sequence in US-ASCII (ArgumentError)
    from /Library/Ruby/Gems/2.0.0/gems/shenzhen-0.5.3/lib/shenzhen/xcodebuild.rb:64:in `settings'
    from /Library/Ruby/Gems/2.0.0/gems/shenzhen-0.5.3/lib/shenzhen/commands/build.rb:51:in `block (2 levels) in <top (required)>'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.1.5/lib/commander/command.rb:180:in `call'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.1.5/lib/commander/command.rb:180:in `call'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.1.5/lib/commander/command.rb:155:in `run'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.1.5/lib/commander/runner.rb:402:in `run_active_command'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.1.5/lib/commander/runner.rb:78:in `run!'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.1.5/lib/commander/delegates.rb:7:in `run!'
    from /Library/Ruby/Gems/2.0.0/gems/commander-4.1.5/lib/commander/import.rb:10:in `block in <top (required)>'
Build step 'Execute shell' marked build as failure
```

I solved that adding `export LC_ALL="en_US.UTF-8"` to my script, so I'm summiting this pull request to warn users about this error, CocoaPods are doing a similar approach.
