### PR TITLE
Fixed command in README for ipa distribute:hockeyapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Shenzhen adds the `ipa` command to your PATH:
 
 #### HockeyApp Distribution
 
-    $ ipa distribute:hockeyapp -t API_TOKEN
+    $ ipa distribute:hockeyapp --token API_TOKEN
 
 > Shenzhen will load credentials from the environment variable `HOCKEYAPP_API_TOKEN` unless otherwise specified.
 


### PR DESCRIPTION
Hi Mattt,

In the README I changed:
`$ ipa distribute:hockeyapp -t API_TOKEN`

to:
`$ ipa distribute:hockeyapp --token API_TOKEN`

I'm pretty sure that `-t` isn't a valid option, correct me if I'm wrong.

Thanks
