### PR TITLE
Fixing a bug where the distribute:ftp command wouldn't replace the CFBundle variables

### DIFF
--- a/lib/shenzhen/plugins/ftp.rb
+++ b/lib/shenzhen/plugins/ftp.rb
@@ -51,7 +51,7 @@ module Shenzhen::Plugins
         Dir.mktmpdir do |dir|
           system "unzip -q #{ipa} -d #{dir} 2> /dev/null"
 
-          plist = Dir["#{dir}/**/Info.plist"].last
+          plist = Dir["#{dir}/**/*.app/Info.plist"].last
 
           substitutions.uniq.each do |substitution|
             key = substitution[1...-1]


### PR DESCRIPTION
This happens because the expression responsible of finding the Info.plist file does not limit its results to the *.app folder only, thus returning files such as *.storyboardc/Info.plist.
