### PR TITLE
Abort on TestFlight upload failure

### DIFF
--- a/lib/shenzhen/plugins/testflight.rb
+++ b/lib/shenzhen/plugins/testflight.rb
@@ -83,7 +83,7 @@ command :'distribute:testflight' do |c|
     when 200...300
       say_ok "Build successfully uploaded to TestFlight"
     else
-      say_error "Error uploading to TestFlight: #{response.body}"
+      say_error "Error uploading to TestFlight: #{response.body}" and abort
     end
   end
 


### PR DESCRIPTION
Provide a non-zero return code if the upload to TestFlight fails.
