### PR TITLE
Fix displaying info for embedded provisioning profile

### DIFF
--- a/lib/shenzhen/commands/info.rb
+++ b/lib/shenzhen/commands/info.rb
@@ -19,7 +19,10 @@ command :info do |c|
 
       tempfile = Tempfile.new(::File.basename(entry.name))
       begin
-        zipfile.extract(entry, tempfile.path)
+        zipfile.extract(entry, tempfile.path) {
+          # override existing tempfile
+          true
+        }
         plist = Plist::parse_xml(`security cms -D -i #{tempfile.path}`)
 
         table = Terminal::Table.new do |t|


### PR DESCRIPTION
Hi all,
I noticed two problems with the functionality of displaying info for embedded provisioning profile. Although they definitely happened for me (ruby 1.9.3p327 (2012-11-10 revision 37606) [x86_64-darwin12.2.1]) I doubt they they were posing problems for everybody - otherwise probably you won't release 0.6.0 in this state.

First problem was with building of the path for embedded.mobileprovision to extract using RubyZip. This path included ".ipa" but it should not. I described it in the commit message for db197d7.

The other problem was with extracting of embedded.mobileprovision. On my mac I got error saying that the destination path exists. To fix it I added a block as the last argument for zipfile.extract which controls the behaviour for this exact situation. I return true to make sure it overrides the existing file.

Again, those fixes solve problems for me. Please review them and see if they can and should be integrated into master. I believe they should :)
