### PR TITLE
Using double quotes for xcodebuild args

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -44,17 +44,17 @@ command :build do |c|
 
     flags = []
     flags << "-sdk #{@sdk}"
-    flags << "-workspace '#{@workspace}'" if @workspace
-    flags << "-project '#{@project}'" if @project
-    flags << "-scheme '#{@scheme}'" if @scheme
-    flags << "-configuration '#{@configuration}'" if @configuration
+    flags << "-workspace \"#{@workspace}\"" if @workspace
+    flags << "-project \"#{@project}\"" if @project
+    flags << "-scheme \"#{@scheme}\"" if @scheme
+    flags << "-configuration \"#{@configuration}\"" if @configuration
 
     @target, @xcodebuild_settings = Shenzhen::XcodeBuild.settings(*flags).detect{|target, settings| settings['WRAPPER_EXTENSION'] == "app"}
     say_error "App settings could not be found." and abort unless @xcodebuild_settings
 
     if !@configuration
       @configuration = @xcodebuild_settings['CONFIGURATION']
-      flags << "-configuration '#{@configuration}'"
+      flags << "-configuration \"#{@configuration}\""
     end
 
     say_warning "Building \"#{@workspace || @project}\" with Scheme \"#{@scheme}\" and Configuration \"#{@configuration}\"\n" if $verbose

--- a/lib/shenzhen/version.rb
+++ b/lib/shenzhen/version.rb
@@ -1,3 +1,3 @@
 module Shenzhen
-  VERSION = '0.6.1'
+  VERSION = '0.6.2'
 end


### PR DESCRIPTION
This fixed a problem I had where one of my targets' names looked like this: `StMary's`

So essentially xcodebuild was looking like this: `xcodebuild ... -scheme 'StMary's'` causing it to error out.

I went ahead and used double quotes on all of the xcodebuild arguments to ensure any wild apostrophes wouldn't break. I only tested this on my personal project where this matters - so I'm not sure about total coverage right now.
