### PR TITLE
Allow whitespace in workspace and project names.

### DIFF
--- a/lib/shenzhen/xcodebuild.rb
+++ b/lib/shenzhen/xcodebuild.rb
@@ -89,7 +89,7 @@ module Shenzhen::XcodeBuild
     private
 
     def args_from_options(options = {})
-      options.reject{|key, value| value.nil?}.collect{|key, value| "-#{key} #{value}"}
+      options.reject{|key, value| value.nil?}.collect{|key, value| "-#{key} '#{value}'"}
     end
   end
 end


### PR DESCRIPTION
Exactly what it says. Discovered this rather subtle bug during a production test and went ahead and fixed it.
