### PR TITLE
Return response.body from testflight to the terminal

### DIFF
--- a/lib/shenzhen/plugins/testflight.rb
+++ b/lib/shenzhen/plugins/testflight.rb
@@ -82,6 +82,7 @@ command :'distribute:testflight' do |c|
     case response.status
     when 200...300
       say_ok "Build successfully uploaded to TestFlight"
+      return response.body
     else
       say_error "Error uploading to TestFlight: #{response.body}" and abort
     end


### PR DESCRIPTION
Made a change to return the response from testflight after a successful upload. Useful for using the information contained in the response after an upload, such as the "install_url" value. I made this modification while using my own wrapper around shenzhen. I think it would benefit others who are doing the same.
