### PR TITLE
Allow S3 region to be nil instead of empty string

### DIFF
--- a/lib/shenzhen/plugins/s3.rb
+++ b/lib/shenzhen/plugins/s3.rb
@@ -89,7 +89,6 @@ command :'distribute:s3' do |c|
     say_error "Missing bucket" and abort unless @bucket
 
     determine_region! unless @region = options.region
-    say_error "Missing region" and abort unless @region
 
     determine_acl! unless @acl = options.acl
     say_error "Missing ACL" and abort unless @acl
@@ -124,7 +123,7 @@ command :'distribute:s3' do |c|
   end
 
   def determine_region!
-    @region ||= ENV['AWS_REGION'] || ""
+    @region ||= ENV['AWS_REGION']
   end
 
   def determine_acl!


### PR DESCRIPTION
Currently, the Shenzhen S3 Plugin defaults the region to the empty string `""`:

``` ruby
def determine_region!
  @region ||= ENV['AWS_REGION'] || ""
end
```

This causes this line:

``` ruby
bucket.objects.create(key, descriptor, :acl => options[:acl])
```

to fail with this exception: `SocketError: getaddrinfo: nodename nor servname provided, or not known` for me, when running with this command:

`ipa distribute:s3 -a "ACCESS_KEY_ID" -s "ACCESS_SECRET_KEY" -b "hz-sdk/bar"`

If I remove the `:region` parameter entirely from the S3 initialization code, or set it to `nil`, then the file uploads successfully. This PR removes the code that defaults region to the empty string.

<hr>

It seems weird to me that I'm the first to run into this though. Perhaps the way the AWS Ruby SDK handles an empty string value for region changed or something?

Ruby Version: ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]

Dependency versions (is there a better way to list these than printing the Gemfile.lock file?):

```
PATH
  remote: .
  specs:
    shenzhen (0.8.2)
      aws-sdk (~> 1.0)
      commander (~> 4.1)
      dotenv (~> 0.7)
      faraday (~> 0.8.9)
      faraday_middleware (~> 0.9)
      json (~> 1.8)
      net-sftp (~> 2.1.2)
      plist (~> 3.1.0)
      rubyzip (~> 1.1)
      security (~> 0.1.3)
      terminal-table (~> 1.4.5)

GEM
  remote: https://rubygems.org/
  specs:
    aws-sdk (1.54.0)
      aws-sdk-v1 (= 1.54.0)
    aws-sdk-v1 (1.54.0)
      json (~> 1.4)
      nokogiri (>= 1.4.4)
    commander (4.2.1)
      highline (~> 1.6.11)
    diff-lcs (1.2.5)
    dotenv (0.11.1)
      dotenv-deployment (~> 0.0.2)
    dotenv-deployment (0.0.2)
    faraday (0.8.9)
      multipart-post (~> 1.2.0)
    faraday_middleware (0.9.1)
      faraday (>= 0.7.4, < 0.10)
    highline (1.6.21)
    json (1.8.1)
    mini_portile (0.6.0)
    multipart-post (1.2.0)
    net-sftp (2.1.2)
      net-ssh (>= 2.6.5)
    net-ssh (2.9.1)
    nokogiri (1.6.3.1)
      mini_portile (= 0.6.0)
    plist (3.1.0)
    rake (10.3.2)
    rspec (3.1.0)
      rspec-core (~> 3.1.0)
      rspec-expectations (~> 3.1.0)
      rspec-mocks (~> 3.1.0)
    rspec-core (3.1.5)
      rspec-support (~> 3.1.0)
    rspec-expectations (3.1.2)
      diff-lcs (>= 1.2.0, < 2.0)
      rspec-support (~> 3.1.0)
    rspec-mocks (3.1.2)
      rspec-support (~> 3.1.0)
    rspec-support (3.1.1)
    rubyzip (1.1.6)
    security (0.1.3)
    terminal-table (1.4.5)

PLATFORMS
  ruby

DEPENDENCIES
  rake
  rspec
  shenzhen!
```
