### PR TITLE
Fix creating empty 'directory' on S3 when not specifying a path

### DIFF
--- a/lib/shenzhen/plugins/s3.rb
+++ b/lib/shenzhen/plugins/s3.rb
@@ -10,7 +10,7 @@ module Shenzhen::Plugins
       end
 
       def upload_build(ipa, options)
-        path = expand_path_with_substitutions_from_ipa_plist(ipa, options[:path])
+        path = expand_path_with_substitutions_from_ipa_plist(ipa, options[:path]) if options[:path]
 
         @s3.buckets.create(options[:bucket]) if options[:create]
 
@@ -20,7 +20,8 @@ module Shenzhen::Plugins
         files << ipa
         files << options[:dsym]
         files.each do |file|
-          key = File.join(path, File.basename(file))
+          basename = File.basename(file)
+          key = path ? File.join(path, basename) : basename
           File.open(file) do |descriptor|
             bucket.objects.create(key, descriptor, :acl => options[:acl])
           end
@@ -94,7 +95,7 @@ command :'distribute:s3' do |c|
     determine_acl! unless @acl = options.acl
     say_error "Missing ACL" and abort unless @acl
 
-    @path = options.path || ""
+    @path = options.path
 
     client = Shenzhen::Plugins::S3::Client.new(@access_key_id, @secret_access_key, @region)
 


### PR DESCRIPTION
Currently if you don't specify a `path` to the S3 plugin, it defaults `path` to the empty string. Then, when `File.join(path, File.basename(file))` is run, a file named `foo.ipa` becomes `/foo.ipa`. This causes the uploaded file to have a double slash in its URL:

https://s3.amazonaws.com/hz-sdk/bar//HeyzapSDKTest.ipa

In S3, this creates a directory without a name where the double slash is. You can still click on the empty space and traverse to the file, but it seemed to be clearly a bug.

![screenshot 2014-10-08 18 06 15](https://cloud.githubusercontent.com/assets/1274145/4569813/597cfbc0-4f51-11e4-95af-9c90a5bb0ca8.png)

Fixing this might be a breaking change for anyone relying on the old behavior, though :(
