### PR TITLE
Add single quotes around password command line argument

### DIFF
--- a/lib/shenzhen/plugins/itunesconnect.rb
+++ b/lib/shenzhen/plugins/itunesconnect.rb
@@ -43,7 +43,7 @@ module Shenzhen::Plugins
         tool = Pathname.new(xcode).parent + "Applications/Application Loader.app/Contents/MacOS/itms/bin/iTMSTransporter"
         tool = tool.to_s.gsub(/ /, '\ ')
 
-        args = [tool.to_s, "-m upload", "-f Package.itmsp", "-u #{@account}", "-p #{@password}"]
+        args = [tool.to_s, "-m upload", "-f Package.itmsp", "-u #{@account}", "-p '#{@password}'"]
         command = args.join(' ').strip
 
         say "#{command}" if verbose?


### PR DESCRIPTION
If there are special characters like &, (, ), ... in the password, the command will fail without the quotes.
