### PR TITLE
Pass down the password instead of the GenericPassword instance

### DIFF
--- a/lib/shenzhen/plugins/itunesconnect.rb
+++ b/lib/shenzhen/plugins/itunesconnect.rb
@@ -106,6 +106,7 @@ command :'distribute:itunesconnect' do |c|
 
     @password = options.password || ENV['ITUNES_CONNECT_PASSWORD']
     if @password ||= Security::GenericPassword.find(:s => Shenzhen::Plugins::ITunesConnect::ITUNES_CONNECT_SERVER, :a => @account)
+      @password = @password.password
       say_ok "Found password in keychain for account: #{@account}" if options.verbose
     else
       determine_itunes_connect_password! unless @password


### PR DESCRIPTION
Hey @mattt, sorry to bother you again with another pull request!

I have switched to storing the password in the keychain, instead of passing it every time as a command line parameter. I've noticed this is not working, because it's passing down an instance of GenericPassword instead of the password itself.