### PR TITLE
Support for Swift

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -52,7 +52,6 @@ command :build do |c|
     flags << %{-project "#{@project}"} if @project
     flags << %{-scheme "#{@scheme}"} if @scheme
     flags << %{-configuration "#{@configuration}"} if @configuration
-    flags << %{-archivePath "#{@archive_path}"}
     flags << %{-xcconfig "#{@xcconfig}"} if @xcconfig
     flags << @xcargs if @xcargs
 

--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -52,6 +52,7 @@ command :build do |c|
     flags << %{-project "#{@project}"} if @project
     flags << %{-scheme "#{@scheme}"} if @scheme
     flags << %{-configuration "#{@configuration}"} if @configuration
+    flags << %{-archivePath "#{@archive_path}"}
     flags << %{-xcconfig "#{@xcconfig}"} if @xcconfig
     flags << @xcargs if @xcargs
 

--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -82,8 +82,10 @@ command :build do |c|
     log "xcrun", "PackageApplication"
     abort unless system %{xcrun -sdk #{@sdk} PackageApplication -v "#{@app_path}" -o "#{@ipa_path}" #{"--embed \"#{options.embed}\"" if options.embed} #{"-s \"#{options.identity}\"" if options.identity} #{'1> /dev/null' unless $verbose}}
 
-    log "zip", "SwiftSupport"
-    abort unless system %{pushd "#{@archive_path}" #{'1> /dev/null' unless $verbose} && zip -y -r "#{@ipa_path}" SwiftSupport #{'> /dev/null' unless $verbose} && popd #{'1> /dev/null' unless $verbose}}
+    if File.directory?(File.join(@archive_path, %{SwiftSupport}))
+      log "zip", "SwiftSupport"
+      abort unless system %{pushd "#{@archive_path}" #{'1> /dev/null' unless $verbose} && zip -y -r "#{@ipa_path}" SwiftSupport #{'> /dev/null' unless $verbose} && popd #{'1> /dev/null' unless $verbose}}
+    end
 
     log "zip", @dsym_filename
     abort unless system %{cp -r "#{@dsym_path}" "#{@destination}" && zip -r "#{@dsym_filename}.zip" "#{@dsym_filename}" #{'> /dev/null' unless $verbose} && rm -rf "#{@dsym_filename}"}


### PR DESCRIPTION
Hi!

This tool is really nice that can distribute to many places or iTunes Connect directly.
BUT, It doesn't support when swift codes are in.

I really want to use iTunes Connect distribution with this tool even though using Swift.
So I'm looking into it.

I found that Xcode Command Line tools doesn't contains SwiftSupport folder when PackageApplication it.
And, SwiftSupport folder is located in Xcode Archive.

So this commits make shenzhen will do archive action and embed SwiftSupport folder directly.
With this, I uploaded app to iTunes Connect successfully, and can distribute it through TestFlight by Apple.

Thanks!