### PR TITLE
Switch API to upload.hockeyapp.net

### DIFF
--- a/lib/shenzhen/plugins/hockeyapp.rb
+++ b/lib/shenzhen/plugins/hockeyapp.rb
@@ -6,7 +6,7 @@ require 'faraday_middleware'
 module Shenzhen::Plugins
   module HockeyApp
     class Client
-      HOSTNAME = 'rink.hockeyapp.net'
+      HOSTNAME = 'upload.hockeyapp.net'
 
       def initialize(api_token)
         @api_token = api_token


### PR DESCRIPTION
In multiple support discussions, HockeyApp has recommended using http://upload.hockeyapp.net instead of http://rink.hockeyapp.net:

* http://support.hockeyapp.net/discussions/problems/23558-360mb-ipa-download-very-slow
* http://support.hockeyapp.net/discussions/problems/32813-slow-upload-times

From my testing using `curl`, the upload of large files has been at least 25% faster.