### PR TITLE
Fixed error with iTunesConnect password

### DIFF
--- a/lib/shenzhen/plugins/itunesconnect.rb
+++ b/lib/shenzhen/plugins/itunesconnect.rb
@@ -105,7 +105,7 @@ command :'distribute:itunesconnect' do |c|
     say_error "Missing Apple ID" and abort unless apple_id
 
     @password = options.password || ENV['ITUNES_CONNECT_PASSWORD']
-    if @password ||= Security::GenericPassword.find(:s => Shenzhen::Plugins::ITunesConnect::ITUNES_CONNECT_SERVER, :a => @account)
+    if @password.nil? && @password = Security::GenericPassword.find(:s => Shenzhen::Plugins::ITunesConnect::ITUNES_CONNECT_SERVER, :a => @account)
       @password = @password.password
       say_ok "Found password in keychain for account: #{@account}" if options.verbose
     else


### PR DESCRIPTION
iTunes Connect password supplied via environment variable or command argument appears to be broken:

    private method `password' called for "<password>":String

I think this code implements the behaviour that was actually intended in commit 585ca00, but I'm unsure. 