### PR TITLE
Save ipas with underscores instead of spaces

### DIFF
--- a/lib/shenzhen/plugins/itunesconnect.rb
+++ b/lib/shenzhen/plugins/itunesconnect.rb
@@ -17,7 +17,7 @@ module Shenzhen::Plugins
         @account = account
         @password = password
         @params = params
-        @filename = File.basename(@ipa)
+        @filename = File.basename(@ipa).tr(" ", "_")
       end
 
       def upload_build!


### PR DESCRIPTION
This should fix #184.