### PR TITLE
Path to generated ipa file is last output

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -90,7 +90,8 @@ command :build do |c|
     log "zip", @dsym_filename
     abort unless system %{cp -r "#{@dsym_path}" "#{@destination}" && zip -r "#{@dsym_filename}.zip" "#{@dsym_filename}" #{'> /dev/null' unless $verbose} && rm -rf "#{@dsym_filename}"}
 
-    say_ok "#{@ipa_path} successfully built"
+    say_ok "Successfully built:"
+    say_ok @ipa_path
   end
 
   private


### PR DESCRIPTION
The absolute path is the last line displayed, which makes it easier for other tools (thinking about [fastlane](http://fastlane.tools) to parse the path to the generated ipa file. 

If anybody finds a better way to pass the path to the generated ipa (e.g. using environment variables), let me know.