### PR TITLE
Added output of generated xcodebuild command

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -75,7 +75,9 @@ command :build do |c|
     actions << :archive unless options.archive == false
 
     ENV['CC'] = nil # Fix for RVM
-    abort unless system %{xcodebuild #{flags.join(' ')} #{actions.join(' ')} #{'1> /dev/null' unless $verbose}}
+    cmd = %{xcodebuild #{flags.join(' ')} #{actions.join(' ')} #{'1> /dev/null' unless $verbose}}
+    say_warning cmd
+    abort unless system cmd
 
     @target, @xcodebuild_settings = Shenzhen::XcodeBuild.settings(*flags).detect{|target, settings| settings['WRAPPER_EXTENSION'] == "app"}
     say_error "App settings could not be found." and abort unless @xcodebuild_settings


### PR DESCRIPTION
This will output the generated `xcodebuild` command before actually running it.

#### Why?
Many submitted GitHub issues are related to build problems: https://github.com/nomad/shenzhen/issues/204, https://github.com/nomad/shenzhen/issues/176 and many more.

First of all, it makes it clear that `shenzhen` uses `xcodebuild` to build the app. Secondly the user can modify the generated build command (e.g. replacing `xcodebuild` with `xctool`, which is what I do if there is a build error)

Example output:

```
(master) $ ipa build
     xcodebuild  Moto Deals.xcworkspace
xcodebuild -sdk iphoneos -workspace "App.xcworkspace" -scheme "Debug" -configuration 'Release' clean build archive 1> /dev/null
....
```