### PR TITLE
Added support for setting the notifications flag for crashlytics

### DIFF
--- a/lib/shenzhen/plugins/crashlytics.rb
+++ b/lib/shenzhen/plugins/crashlytics.rb
@@ -16,7 +16,7 @@ module Shenzhen::Plugins
         command += " -notesPath #{options[:notes]}" if options[:notes]
         command += " -emails #{options[:emails]}" if options[:emails]
         command += " -groupAliases #{options[:groups]}" if options[:groups]
-        command += " -notifications #{options[:notifications]}" if options[:notifications]
+        command += " -notifications #{options[:notifications] ? 'YES' : 'NO'}" if options[:notifications]
 
         system command
       end
@@ -55,7 +55,7 @@ command :'distribute:crashlytics' do |c|
     parameters[:notes] = options.notes if options.notes
     parameters[:emails] = options.emails if options.emails
     parameters[:groups] = options.groups if options.groups
-    parameters[:notifications] = options.notifications if options.notifications
+    parameters[:notifications] = options.notifications == 'YES' if options.notifications
 
     client = Shenzhen::Plugins::Crashlytics::Client.new(@crashlytics_path, @api_token, @build_secret)
 

--- a/lib/shenzhen/plugins/crashlytics.rb
+++ b/lib/shenzhen/plugins/crashlytics.rb
@@ -16,6 +16,7 @@ module Shenzhen::Plugins
         command += " -notesPath #{options[:notes]}" if options[:notes]
         command += " -emails #{options[:emails]}" if options[:emails]
         command += " -groupAliases #{options[:groups]}" if options[:groups]
+        command += " -notifications #{options[:notifications]}" if options[:notifications]
 
         system command
       end
@@ -34,6 +35,7 @@ command :'distribute:crashlytics' do |c|
   c.option '-m', '--notes PATH', "Path to release notes file"
   c.option '-e', '--emails EMAIL1,EMAIL2', "Emails of users for access"
   c.option '-g', '--groups GROUPS', "Groups for users for access"
+  c.option '-n', '--notifications [YES | NO]', "Should send notification email to testers?"
 
   c.action do |args, options|
     determine_file! unless @file = options.file
@@ -53,6 +55,7 @@ command :'distribute:crashlytics' do |c|
     parameters[:notes] = options.notes if options.notes
     parameters[:emails] = options.emails if options.emails
     parameters[:groups] = options.groups if options.groups
+    parameters[:notifications] = options.notifications if options.notifications
 
     client = Shenzhen::Plugins::Crashlytics::Client.new(@crashlytics_path, @api_token, @build_secret)
 


### PR DESCRIPTION
Useful for CI if don't want to spam users every time a new build is available.

http://support.crashlytics.com/knowledgebase/articles/370383-beta-distribution-with-ios-build-servers