### PR TITLE
Change verbose mode on itunesconnect to hide pass

### DIFF
--- a/lib/shenzhen/plugins/itunesconnect.rb
+++ b/lib/shenzhen/plugins/itunesconnect.rb
@@ -44,11 +44,12 @@ module Shenzhen::Plugins
       def transport
         xcode = `xcode-select --print-path`.strip
         tool = File.join(File.dirname(xcode), "Applications/Application Loader.app/Contents/MacOS/itms/bin/iTMSTransporter").gsub(/\s/, '\ ')
-
-        args = [tool, "-m upload", "-f Package.itmsp", "-u #{Shellwords.escape(@account)}", "-p #{Shellwords.escape(@password)}"]
+        
+        escaped_password = Shellwords.escape(@password)
+        args = [tool, "-m upload", "-f Package.itmsp", "-u #{Shellwords.escape(@account)}", "-p #{escaped_password}"]
         command = args.join(' ')
 
-        puts "#{command}" if $verbose
+        puts "#{command.sub(escaped_password, '*****')}" if $verbose
 
         output = `#{command} 2> /dev/null`
         puts output.chomp if $verbose


### PR DESCRIPTION
Without verbose, the plugin doesn't show much data if something goes wrong. 
With verbose mode, the itunesconnect plugin was echoing the account's password. 
On a CI environment, it's important to have debug output but I'd rather keep my password hidden.