### PR TITLE
Use new path to iTMSTransporter when needed

### DIFF
--- a/lib/shenzhen/plugins/itunesconnect.rb
+++ b/lib/shenzhen/plugins/itunesconnect.rb
@@ -44,6 +44,7 @@ module Shenzhen::Plugins
       def transport
         xcode = `xcode-select --print-path`.strip
         tool = File.join(File.dirname(xcode), "Applications/Application Loader.app/Contents/MacOS/itms/bin/iTMSTransporter").gsub(/\s/, '\ ')
+        tool = File.join(File.dirname(xcode), "Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter").gsub(/\s/, '\ ') if !File.exist?(tool)
 
         args = [tool, "-m upload", "-f Package.itmsp", "-u #{Shellwords.escape(@account)}", "-p #{Shellwords.escape(@password)}"]
         command = args.join(' ')


### PR DESCRIPTION
Xcode 6.3 moved the path to the iTMSTransporter. This tries to use the original path and uses the new one if the file doesn't exist.

This addresses #243.