### PR TITLE
Fail loudly when the transporter returns a non-zero exit code.

### DIFF
--- a/lib/shenzhen/plugins/itunesconnect.rb
+++ b/lib/shenzhen/plugins/itunesconnect.rb
@@ -53,6 +53,8 @@ module Shenzhen::Plugins
         output = `#{command} 2> /dev/null`
         puts output.chomp if $verbose
 
+        raise 'Failed to upload package to iTunes Connect' unless $?.exitstatus == 0
+
         output
       end
 


### PR DESCRIPTION
This should be added in addition to #245 . We look for the exit status of the transporter command and raise an error when it returns a non-zero exit code.

This would have allowed us to pin point where the failure was much faster when our builds stopped making it to iTunes Connect.