### PR TITLE
Include code sign status in ipa info

### DIFF
--- a/lib/shenzhen/commands/info.rb
+++ b/lib/shenzhen/commands/info.rb
@@ -15,23 +15,23 @@ command :info do |c|
     say_error "Missing or unspecified .ipa file" and abort unless @file and ::File.exist?(@file)
 
     Zip::File.open(@file) do |zipfile|
-      entry = zipfile.find_entry("Payload/#{File.basename(@file, File.extname(@file))}.app/embedded.mobileprovision")
+      provisioning_profile_entry = zipfile.find_entry("Payload/#{File.basename(@file, File.extname(@file))}.app/embedded.mobileprovision")
       
-      if (!entry)
+      if (!provisioning_profile_entry)
         zipfile.dir.entries("Payload").each do |dir_entry|
           if dir_entry =~ /.app$/
             say "Using .app: #{dir_entry}"
-            entry = zipfile.find_entry("Payload/#{dir_entry}/embedded.mobileprovision")
+            provisioning_profile_entry = zipfile.find_entry("Payload/#{dir_entry}/embedded.mobileprovision")
             break
           end
         end
       end
 
-      say_error "Embedded mobile provisioning file not found in #{@file}" and abort unless entry
+      say_error "Embedded mobile provisioning file not found in #{@file}" and abort unless provisioning_profile_entry
 
-      tempfile = Tempfile.new(::File.basename(entry.name))
+      tempfile = Tempfile.new(::File.basename(provisioning_profile_entry.name))
       begin
-        zipfile.extract(entry, tempfile.path){ override = true }
+        zipfile.extract(provisioning_profile_entry, tempfile.path){ override = true }
         plist = Plist::parse_xml(`security cms -D -i #{tempfile.path}`)
 
         table = Terminal::Table.new do |t|

--- a/lib/shenzhen/commands/info.rb
+++ b/lib/shenzhen/commands/info.rb
@@ -46,7 +46,7 @@ command :info do |c|
         plist = Plist::parse_xml(`security cms -D -i #{temp_provisioning_profile.path}`)
 
         codesign = `codesign -dv "#{temp_app_directory.path}" 2>&1`
-        signed = /Signed Time/ === codesign
+        codesigned = /Signed Time/ === codesign
 
         table = Terminal::Table.new do |t|
           plist.each do |key, value|
@@ -65,6 +65,8 @@ command :info do |c|
 
             t << columns
           end
+
+          t << ["Codesigned", codesigned.to_s.capitalize]
         end
 
         puts table

--- a/lib/shenzhen/commands/info.rb
+++ b/lib/shenzhen/commands/info.rb
@@ -41,8 +41,12 @@ command :info do |c|
         end
 
         temp_provisioning_profile = ::File.new(::File.join(tempdir.path, provisioning_profile_entry.name))
+        temp_app_directory = ::File.new(::File.join(tempdir.path, app_entry.name))
 
         plist = Plist::parse_xml(`security cms -D -i #{temp_provisioning_profile.path}`)
+
+        codesign = `codesign -dv "#{temp_app_directory.path}" 2>&1`
+        signed = /Signed Time/ === codesign
 
         table = Terminal::Table.new do |t|
           plist.each do |key, value|

--- a/lib/shenzhen/commands/info.rb
+++ b/lib/shenzhen/commands/info.rb
@@ -15,13 +15,15 @@ command :info do |c|
     say_error "Missing or unspecified .ipa file" and abort unless @file and ::File.exist?(@file)
 
     Zip::File.open(@file) do |zipfile|
-      provisioning_profile_entry = zipfile.find_entry("Payload/#{File.basename(@file, File.extname(@file))}.app/embedded.mobileprovision")
+      app_entry = zipfile.find_entry("Payload/#{File.basename(@file, File.extname(@file))}.app")
+      provisioning_profile_entry = zipfile.find_entry("#{app_entry.name}embedded.mobileprovision") if app_entry
       
       if (!provisioning_profile_entry)
         zipfile.dir.entries("Payload").each do |dir_entry|
           if dir_entry =~ /.app$/
             say "Using .app: #{dir_entry}"
-            provisioning_profile_entry = zipfile.find_entry("Payload/#{dir_entry}/embedded.mobileprovision")
+            app_entry = zipfile.find_entry("Payload/#{dir_entry}")
+            provisioning_profile_entry = zipfile.find_entry("#{app_entry.name}embedded.mobileprovision") if app_entry
             break
           end
         end

--- a/lib/shenzhen/commands/info.rb
+++ b/lib/shenzhen/commands/info.rb
@@ -10,6 +10,7 @@ command :info do |c|
 
   c.action do |args, options|
     say_error "`security` command not found in $PATH" and abort if `which security` == ""
+    say_error "`codesign` command not found in $PATH" and abort if `which codesign` == ""
 
     determine_file! unless @file = args.pop
     say_error "Missing or unspecified .ipa file" and abort unless @file and ::File.exist?(@file)


### PR DESCRIPTION
Added information about the code signing status of the IPA when using the `ipa info`-command.
I use this command in my CI environment to log information about the artifacts that my build script produces. As a step in my artifact verification I wanted to make sure that some (but not all) builds are code signed correctly.

Solved this by extracting the entire ipa to a temporary directory and using the codesign command on the extracted app.