### PR TITLE
Output error when the response of deploygate.com has an error param

### DIFF
--- a/lib/shenzhen/plugins/deploygate.rb
+++ b/lib/shenzhen/plugins/deploygate.rb
@@ -80,9 +80,13 @@ command :'distribute:deploygate' do |c|
     response = client.upload_build(@file, parameters)
     case response.status
     when 200...300
-      say_ok "Build successfully uploaded to DeployGate"
+      if response.body["error"] then
+          say_error "Error uploading to DeployGate: code=#{response.status}, body=#{response.body}" and abort
+      else
+          say_ok "Build successfully uploaded to DeployGate"
+      end
     else
-      say_error "Error uploading to DeployGate: #{response.body}" and abort
+      say_error "Error uploading to DeployGate: code=#{response.status}, body=#{response.body}" and abort
     end
   end
 


### PR DESCRIPTION
DeployGate can return a response with status code 200 and an error of body.

`ipa distribute:deploygate` command outputs `Build successfully uploaded to DeployGate` like below when a user set an invalid token. It's an inappropriate message because uploading is failed in fact.

```ruby
$ ipa distribute:deploygate -a [INVALID_TOKEN] -u yoheimuta -f DemoApp.ipa -m "dummy message" -n
Build successfully uploaded to DeployGate
```

I think the response with error should cause to output an error message and be aborted like below.

```ruby
# Used an invalid API key
$ ipa distribute:deploygate -a [INVALID_TOKEN] -u yoheimuta -f DemoApp.ipa -m "dummy message" -n
Error uploading to DeployGate: code=200, body={"error"=>true, "message"=>"you are not authenticated", "because"=>"you are not authenticated"}
# Used a valid API key
$ ipa distribute:deploygate -a [VALID_TOKEN] -u yoheimuta -f DemoApp.ipa -m "dummy message" -n
Build successfully uploaded to DeployGate
```