### PR TITLE
Adding WatchKitSupport folder to zipped .ipa for WatchKit apps

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -122,20 +122,20 @@ command :build do |c|
       end
     end
 
-		log "Adding WatchKit support files", "#{xcode}/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/Library/Application Support/WatchKit/WK"
-		Dir.mktmpdir do |tmpdir|
-			# Make watchkit support directory
+    log "Adding WatchKit support files", "#{xcode}/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/Library/Application Support/WatchKit/WK"
+    Dir.mktmpdir do |tmpdir|
+      # Make watchkit support directory
       watchkit_support = File.join(tmpdir, "WatchKitSupport")
-			Dir.mkdir(watchkit_support)
-			
-			# Copy WK from Xcode into WatchKitSupport
-			FileUtils.copy_file("#{xcode}/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/Library/Application Support/WatchKit/WK", File.join(watchkit_support, "WK"))
+      Dir.mkdir(watchkit_support)
 
-			# Add "WatchKitSupport" to the .ipa archive
+      # Copy WK from Xcode into WatchKitSupport
+      FileUtils.copy_file("#{xcode}/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/Library/Application Support/WatchKit/WK", File.join(watchkit_support, "WK"))
+
+      # Add "WatchKitSupport" to the .ipa archive
       Dir.chdir(tmpdir) do
         abort unless system %{zip --recurse-paths "#{@ipa_path}" "WatchKitSupport" #{'> /dev/null' unless $verbose}}
       end
-		end
+    end
 
     log "zip", @dsym_filename
     abort unless system %{cp -r "#{@dsym_path}" "#{@destination}" && pushd "#{File.dirname(@dsym_filename)}" && zip -r "#{@dsym_filename}.zip" "#{File.basename(@dsym_filename)}" #{'> /dev/null' unless $verbose} && popd && rm -rf "#{@dsym_filename}"}

--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -69,6 +69,8 @@ command :build do |c|
 
     log "xcodebuild", (@workspace || @project)
 
+    xcode = `xcode-select --print-path`.strip
+
     actions = []
     actions << :clean unless options.clean == false
     actions << :build
@@ -93,6 +95,7 @@ command :build do |c|
     puts command if $verbose
     abort unless system command
 
+
     # Determine whether this is a Swift project and, eventually, the list of libraries to copy from
     # Xcode's toolchain directory since there's no "xcodebuild" target to do just that (it is done
     # post-build when exporting an archived build from the "Organizer").
@@ -106,8 +109,6 @@ command :build do |c|
 
         Dir.mkdir(swift_support)
 
-        xcode = `xcode-select --print-path`.strip
-
         @ipa_swift_frameworks.each do |path|
           framework = File.basename(path)
 
@@ -120,6 +121,21 @@ command :build do |c|
         end
       end
     end
+
+		log "Adding WatchKit support files", "#{xcode}/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/Library/Application Support/WatchKit/WK"
+		Dir.mktmpdir do |tmpdir|
+			# Make watchkit support directory
+      watchkit_support = File.join(tmpdir, "WatchKitSupport")
+			Dir.mkdir(watchkit_support)
+			
+			# Copy WK from Xcode into WatchKitSupport
+			FileUtils.copy_file("#{xcode}/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/Library/Application Support/WatchKit/WK", File.join(watchkit_support, "WK"))
+
+			# Add "WatchKitSupport" to the .ipa archive
+      Dir.chdir(tmpdir) do
+        abort unless system %{zip --recurse-paths "#{@ipa_path}" "WatchKitSupport" #{'> /dev/null' unless $verbose}}
+      end
+		end
 
     log "zip", @dsym_filename
     abort unless system %{cp -r "#{@dsym_path}" "#{@destination}" && pushd "#{File.dirname(@dsym_filename)}" && zip -r "#{@dsym_filename}.zip" "#{File.basename(@dsym_filename)}" #{'> /dev/null' unless $verbose} && popd && rm -rf "#{@dsym_filename}"}


### PR DESCRIPTION
If you attempt to submit an .ipa built using shenzhen that contains a WatchKit app the upload will succeed but you'll receive an error email from iTunes with this message:

Invalid WatchKit Support - The bundle contains an invalid implementation of WatchKit. The app may have been built or signed with non-compliant or pre-release tools. Visit developer.apple.com for more information.

This stackoverflow answer explains how to fix it:
http://stackoverflow.com/a/29400301/2418382

This pull request adds the necessary WatchKitSupport folder and WK binary so that the .ipa is valid.