### PR TITLE
Allow dotenv >= 0.7

### DIFF
--- a/shenzhen.gemspec
+++ b/shenzhen.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json", "~> 1.8"
   s.add_dependency "faraday", "~> 0.8.9"
   s.add_dependency "faraday_middleware", "~> 0.9"
-  s.add_dependency "dotenv", "~> 0.7"
+  s.add_dependency "dotenv", ">= 0.7"
   s.add_dependency "aws-sdk", "~> 1.0"
   s.add_dependency "net-sftp", "~> 2.1.2"
   s.add_dependency "plist", "~> 3.1.0"


### PR DESCRIPTION
### Motivation

The current release of dotenv is 2.0.1 (April 3 2015).

I am a new user, so I don't yet know how dotenv is used in this project.  I cannot say for sure how this change will affect this gem's behavior.   It is not clear to me that dotenv is even used in this project; I don't see a call to Dotenv.load.

The ~> 0.7 conflicts with a couple of other gems I use.
