### PR TITLE
Call xcodebuild in the context of xcrun

### DIFF
--- a/lib/shenzhen/xcodebuild.rb
+++ b/lib/shenzhen/xcodebuild.rb
@@ -29,7 +29,7 @@ module Shenzhen::XcodeBuild
   class << self
     def info(*args)
       options = args.last.is_a?(Hash) ? args.pop : {}
-      output = `xcodebuild -list #{(args + args_from_options(options)).join(" ")} 2>&1`
+      output = `xcrun xcodebuild -list #{(args + args_from_options(options)).join(" ")} 2>&1`
 
       raise Error.new $1 if /^xcodebuild\: error\: (.+)$/ === output
 
@@ -62,7 +62,7 @@ module Shenzhen::XcodeBuild
 
     def settings(*args)
       options = args.last.is_a?(Hash) ? args.pop : {}
-      output = `xcodebuild #{(args + args_from_options(options)).join(" ")} -showBuildSettings 2> /dev/null`
+      output = `xcrun xcodebuild #{(args + args_from_options(options)).join(" ")} -showBuildSettings 2> /dev/null`
 
       return nil unless /\S/ === output
 
@@ -86,7 +86,7 @@ module Shenzhen::XcodeBuild
     end
 
     def version
-      output = `xcodebuild -version`
+      output = `xcrun xcodebuild -version`
       output.scan(/([\d+\.?]+)/).flatten.first rescue nil
     end
 


### PR DESCRIPTION
### Motivation

I work in an environment where I have to test and build against multiple Xcode versions. I use a combination of `xcode-select`, `xcrun`, and `DEVELOPER_DIR` to control the active Xcode.

Rather than using `sudo xcode-select` to force a particular Xcode version (in CI environments for example) I use:

```
$ DEVELOPER_DIR=/path/to/Xcode.app/Contents/Developer xcrun xcodebuild
```

I would like to be able to use this gem in a similar way:

```
$ DEVELOPER_DIR=/path/to/Xcode.app/Contents/Developer ipa
```

* `$ man xcode-select`
* `$ man xcrun`
