### PR TITLE
Print HockeyApp response body in verbose mode

### DIFF
--- a/lib/shenzhen/plugins/hockeyapp.rb
+++ b/lib/shenzhen/plugins/hockeyapp.rb
@@ -105,6 +105,7 @@ command :'distribute:hockeyapp' do |c|
     response = client.upload_build(@file, parameters)
     case response.status
     when 200...300
+      puts response.body if $verbose
       say_ok "Build successfully uploaded to HockeyApp"
     else
       say_error "Error uploading to HockeyApp: #{response.body}"


### PR DESCRIPTION
As part of continuous integration shell scripts, I want to get the response body and grep additional information from it, such as direct link to newly uploaded version in HockeyApp and so on. The reason to do that is to be able to get, for example, HockeyApp link and publish it as part of Jenkins build job summary.

This is what I used to get while using `curl` directly, but with switch to `ipa` I have no way to get detailed information about upload.
