### PR TITLE
Fixed issue with search path containing spaces to security command

### DIFF
--- a/lib/shenzhen/commands/info.rb
+++ b/lib/shenzhen/commands/info.rb
@@ -44,7 +44,7 @@ command :info do |c|
         temp_provisioning_profile = ::File.new(::File.join(tempdir.path, provisioning_profile_entry.name))
         temp_app_directory = ::File.new(::File.join(tempdir.path, app_entry.name))
 
-        plist = Plist::parse_xml(`security cms -D -i #{temp_provisioning_profile.path}`)
+        plist = Plist::parse_xml(`security cms -D -i "#{temp_provisioning_profile.path}"`)
 
         codesign = `codesign -dv "#{temp_app_directory.path}" 2>&1`
         codesigned = /Signed Time/ === codesign


### PR DESCRIPTION
This fixes issue #271 with .app-files containing spaces.
The search path needs to be quoted since the spaces are not escaped otherwise.
