### PR TITLE
Fixed options "clean, build, archive" evaluation

### DIFF
--- a/lib/shenzhen/commands/build.rb
+++ b/lib/shenzhen/commands/build.rb
@@ -72,9 +72,9 @@ command :build do |c|
     xcode = `xcode-select --print-path`.strip
 
     actions = []
-    actions << :clean unless options.clean == false
-    actions << :build
-    actions << :archive unless options.archive == false
+    actions << :clean unless options.clean == nil || options.clean == false
+    actions << :build unless options.archive == true
+    actions << :archive unless options.archive == nil || options.archive == false
 
     ENV['CC'] = nil # Fix for RVM
     command = %{xcodebuild #{flags.join(' ')} #{actions.join(' ')} #{'1> /dev/null' unless $verbose}}


### PR DESCRIPTION
"clean, build, archive" were only checked for false. If a argument is not specified the argument is nil, so the check for false will fail. The "build" argument will only be added if "archive" is not specified, because if not, xcodebuild will build the app two times (one time for "build" and one time for "archive").
